### PR TITLE
prevent type error exception when 429s are thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,9 @@ module.exports = class TokenManager {
           error.statusCode = resp.statusCode // the http status code
           error.error = resp.body // the error body
           error.options = options
-          error.error.error = error.error.errorMessage
+          if (typeof error.error === 'object') {
+            error.error.error = error.error.errorMessage
+          }
           return Promise.reject(error)
         } else {
           // otherwise, the response body is the expected return value


### PR DESCRIPTION
When 429s are thrown due to throttling `error.error=resp.body` is a string so code should only retrieve `error.error.errorMessage` if type is an object.