### PR TITLE
package.json: engine.npm set to '^6.x'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "engines": {
     "node": "^12.x",
-    "npm": "6.4.1"
+    "npm": "^6.x"
   },
   "scripts": {
     "test": "npm run lint && npm run jest",


### PR DESCRIPTION
- it was too strict before, and failed with the latest Node.js 12.x

Fixes: https://github.com/ibm-functions/iam-token-manager-nodejs/issues/8

Repro-check as shown:

1. clone this repo, and in that repo:
2. `nvm i 12`
3. `npm config set engine-strict true`
4. `npm i`

Before this fix: fails as below.
After this fix: succeeds.

```
$ npm i
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @ibm-functions/iam-token-manager@1.0.4: wanted: {"node":"^12.x","npm":"6.4.1"} (current: {"node":"12.17.0","npm":"6.14.5"})
```