### PR TITLE
Added Promise-with-expiration support for needle requests

### DIFF
--- a/__tests__/tokens.spec.js
+++ b/__tests__/tokens.spec.js
@@ -36,3 +36,16 @@ test('should call requestToken() only once with many parallel getAuthHeader() ca
       spy2.mockRestore()
     })
 })
+test('should properly timeout on network slowness', () => {
+  jest.setTimeout(120000)
+  needle.mockResolvedValue(new Promise((resolve) => {
+    setTimeout(() => { resolve(validToken) }, 100000) // current limit is 90000 for the Promise timeout
+  }))
+  return tm.getAuthHeader()
+    .then(resp => {
+      jest.fail('Got response, but expected an Error')
+    })
+    .catch(err => {
+      expect(err).toEqual(new Error('Promise timed out after 90000 milliseconds.'))
+    })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibm-functions/iam-token-manager",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibm-functions/iam-token-manager",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Helper library to handle IBM Cloud IAM Tokens",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
With this PR, I'm adding support for letting a Promise returned by needle time out after 90 seconds, in case the needle promise never settles (i.e. it neither resolves nor rejects). This could lead to a dead-end for a user of the iam-token-manager, since all further requests for a token would wait on that same unsettled promise literally forever. 

With the timeout support, an issue of the above kind would self-resolve and a new needle request would be sent after the Promise timed out.