### PR TITLE
Allow users of this module to use npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "engines": {
     "node": "^12.x",
-    "npm": "^6.x"
+    "npm": ">=6"
   },
   "scripts": {
     "test": "npm run lint && npm run jest",


### PR DESCRIPTION
Prevent EBADENGINE when packages that reference this module run `npm install` with npm version 7.

I am attempting to use this package from a project that requires npm version 7. We use `engine-strict=true` in .npmrc to ensure that the node version is correct. Unfortunately this causes npm to balk at installing npm-token-manager since it requires npm version 6:

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @ibm-functions/iam-token-manager@1.0.5
npm ERR! notsup Not compatible with your version of node/npm: @ibm-functions/iam-token-manager@1.0.5
npm ERR! notsup Required: {"node":"^12.x","npm":"^6.x"}
npm ERR! notsup Actual:   {"npm":"7.20.0","node":"v12.20.2"}
```

After making this suggested change, I ran `npm install` and `npm test` using npm version 7 without problem.